### PR TITLE
Fix silent failures in the existing modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The tools will by default be installed to `~/.local/share/releasetools/cli/VERSI
 export PATH=~/.local/bin:"$PATH"
 
 # You can run commands, e.g.:
-releasetools base::::version
+releasetools version
 # vX.Y.Z
 
 # Optionally, check that all dependencies for all modules are correctly installed

--- a/scripts/generate-dist.sh
+++ b/scripts/generate-dist.sh
@@ -45,9 +45,17 @@ readonly VERSION
 
 # Parses a module, applying any required post-processing
 function _parse_module() {
-  # Do not include the shebang line
-  # And replace the version placeholder
-  sed '/^#!\/usr\/bin\/env bash/d' "$1" | sed "s/{{version}}/$VERSION/g"
+  # Do not include the shebang line, and replace the version placeholder.
+  #
+  # The shebang deletion is anchored to line 1: unanchored, it also deleted matching lines
+  # from the middle of a module (inside a heredoc, for instance), silently.
+  #
+  # The version is escaped for use as a sed replacement, so a version containing '/' or '&'
+  # cannot corrupt the substitution.
+  local escaped_version
+  escaped_version="$(printf '%s' "$VERSION" | sed -e 's/[\/&\\]/\\&/g')"
+
+  sed '1{/^#!\/usr\/bin\/env bash$/d;}' "$1" | sed "s/{{version}}/$escaped_version/g"
 }
 
 echo "Concatenating modules into '$OUTPUT_FILE', version '$VERSION'." >&2
@@ -94,11 +102,20 @@ echo "Adding base::check_deps()" >&2
 {
   echo ""
   echo "# Ensure all dependencies are installed"
+  echo "#"
+  echo "# Every namespace is checked, so a single failure does not hide the rest, and the"
+  echo "# accumulated status is returned. The previous form ended each line with a subshell"
+  echo "# ('|| ( ... && exit 1 )'), whose 'exit' could only leave the subshell -- so the"
+  echo "# function reported 'Ok.' and returned 0 wherever 'set -e' was suppressed."
   echo "function base::check_deps() {"
+  echo "  local rc=0"
   for m in "${modules[@]}"; do
-    echo "  $m::_internal_check_deps || (echo \"ERROR: $m::_internal_check_deps\" >&2 && exit 1)"
+    echo "  $m::_internal_check_deps || { echo \"ERROR: $m::_internal_check_deps\" >&2; rc=1; }"
   done
-  echo "echo \"Ok.\" >&2"
+  echo "  if [ \"\$rc\" -ne 0 ]; then"
+  echo "    return \"\$rc\""
+  echo "  fi"
+  echo "  echo \"Ok.\" >&2"
   echo "}"
   echo ""
 } >>"$OUTPUT_FILE"
@@ -116,7 +133,7 @@ chmod +x "$OUTPUT_FILE"
 
 # Generate the checksum
 CHECKSUM_FILE="$OUTPUT_FILE.sha256"
-pushd "$(dirname "$OUTPUT_FILE")" >&2 >/dev/null || exit 1
+pushd "$(dirname "$OUTPUT_FILE")" >/dev/null || exit 1
 shasum -a 256 "$(basename "$OUTPUT_FILE")" >"$CHECKSUM_FILE"
 echo "Checksum stored in '$CHECKSUM_FILE'." >&2
-popd >&2 >/dev/null || exit 1
+popd >/dev/null || exit 1

--- a/scripts/generate-install.sh
+++ b/scripts/generate-install.sh
@@ -35,6 +35,11 @@ source "$DIR/src/git.bash"
 # Determine the version
 VERSION="$(git::version_or_sha)"
 
-echo "Injecting version $VERSION into $INPUT_SCRIPT..." >&2
-sed "s/{{version}}/$VERSION/g" "$INPUT_SCRIPT" >"$OUTPUT_FILE"
+# Escaped for use as a sed replacement, matching generate-dist.sh: an unescaped '&' in the
+# version silently expanded to the whole match, and a '/' made sed fail mid-file.
+ESCAPED_VERSION="$(printf '%s' "$VERSION" | sed -e 's/[\/&\\]/\\&/g')"
+readonly ESCAPED_VERSION
+
+echo "Injecting version $VERSION into $(basename "$OUTPUT_FILE")..." >&2
+sed "s/{{version}}/$ESCAPED_VERSION/g" "$INPUT_SCRIPT" >"$OUTPUT_FILE"
 chmod +x "$OUTPUT_FILE" >&2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,7 +80,13 @@ fi
 # Perform checksum verification
 cwd="$(pwd -P)"
 cd "$INSTALL_DIR" >&2
-shasum -a 256 -c "$NAME.sha256" >&2 >/dev/null || (echo "Checksum verification failed!" >&2 && exit 1)
+# The 'exit 1' has to run in this shell, not a subshell, to actually abort the install.
+# Only stdout is discarded: shasum's own diagnostic on stderr is the reason a verification
+# failed, and it is the only clue available inside a GitHub Actions step.
+if ! shasum -a 256 -c "$NAME.sha256" >/dev/null; then
+  echo "Checksum verification failed!" >&2
+  exit 1
+fi
 cd "$cwd" >&2 # return to the previous directory
 
 # Make the script executable

--- a/src/git.bash
+++ b/src/git.bash
@@ -38,19 +38,43 @@ function git::is_dirty() {
 # working directory contains uncommitted changes.
 function git::head_sha() {
     local git_sha
-    git_sha="$(git rev-parse --short HEAD)"
+
+    # Checked explicitly: as a bare assignment this failed via 'set -e', which kills the
+    # caller's shell outright when the library has been sourced, with no explanation.
+    if ! git_sha="$(git rev-parse --short HEAD)"; then
+        echo "ERROR: could not resolve HEAD; is this a git repository with any commits?" >&2
+        return 1
+    fi
 
     echo "${git_sha}$(git::is_dirty)"
 }
 
-# Returns a version tag (e.g. 'v#') associated with the current branch's HEAD.
+# Returns a version tag (e.g. 'v#') pointing at the current branch's HEAD.
 #
 # This function will strip the 'v' prefix from the tag (e.g. 'v1.0.0' is returned as '1.0.0').
-# If multiple tags are found, the most recent one (naturally sorted) is returned.
-# Returns an empty string, if no tags are not found.
+# If multiple tags point at HEAD, the highest version is returned; the comparison is
+# by version, not lexical, so 'v0.0.10' correctly outranks 'v0.0.9'.
+# Returns an empty string if no version tag points at HEAD.
 function git::version_tag() {
+    local tags
     local tag
-    tag="$(git tag --contains HEAD | grep -sE '^v' | sort | tail -1)"
+
+    # '--points-at' matches only tags on HEAD itself. '--contains' would also match tags on
+    # descendant commits, which made re-running a release for an older tag resolve to the
+    # newest one instead.
+    #
+    # The 'v[0-9]*' pattern is handed to git rather than piped through grep, so that a
+    # genuine git failure cannot be mistaken for "HEAD carries no version tag" -- git exits
+    # 0 with no output when nothing matches, and non-zero only when it actually failed.
+    if ! tags="$(git -c 'versionsort.suffix=-' tag --points-at HEAD --sort='-version:refname' 'v[0-9]*')"; then
+        echo "ERROR: could not list git tags" >&2
+        return 1
+    fi
+
+    # Keep the highest version. Done with parameter expansion rather than 'head -1' so that
+    # closing the pipe early cannot surface as a SIGPIPE failure under 'set -o pipefail'.
+    tag="${tags%%$'\n'*}"
+
     echo "${tag#v}"
 }
 
@@ -58,17 +82,28 @@ function git::version_tag() {
 # or the SHA of the HEAD commit if no tags are found.
 function git::version_or_sha() {
     local version
-    version="v$(git::version_tag)"
+    if ! version="$(git::version_tag)"; then
+        return 1
+    fi
 
-    # If no version tag was found, use the SHA
-    if [ -z "$version" ]; then
+    if [ -n "$version" ]; then
+        # Restore the 'v' prefix that git::version_tag strips. Prefixing before this test
+        # (as the previous version did) made the string never empty, so the SHA fallback
+        # below was unreachable and an untagged HEAD resolved to the literal 'v'.
+        #
+        # No dirty marker here, deliberately: this value is baked into install.sh's download
+        # URL, so a 'v1.2.3-dirty' would 404 for every consumer. The tag is the release
+        # identity; use git::head_sha when you need to know the tree was modified.
+        version="v$version"
+    else
+        # If no version tag was found, use the SHA
         version="$(git::head_sha)"
     fi
 
     # Fail if neither could be determined
     if [ -z "$version" ]; then
         echo "ERROR: could not determine version or SHA" >&2
-        exit 1
+        return 1
     fi
 
     echo "$version"
@@ -77,21 +112,30 @@ function git::version_or_sha() {
 # Returns the most recent known version tag from the remote repository (origin)
 function git::latest_version() {
     local repo
-    repo="$(git config --get remote.origin.url)"
+
+    if ! repo="$(git config --get remote.origin.url)"; then
+        echo "ERROR: no 'origin' remote is configured" >&2
+        return 1
+    fi
+
     git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags "$repo" 'v*.*.*' | tail -1 | cut -d'/' -f3
 }
 
 # Creates a release tag for the current HEAD commit.
 #
-# Requires one argument, a semantic version string (e.g. 'v1.2.3').
+# Requires exactly one argument, a semantic version string (e.g. 'v1.2.3').
 # If the version string does not match the semver format, the function
 # will terminate with an error.
 #
+# if '--sign, -s' is specified, the tag(s) will be GPG-signed
 # if '--force, -f' is specified, existing tags will be overwritten
 # if '--push, -p' is specified, the tag(s) will also be pushed to the remote
 # if '--major, -m' is specified, a separate major version tag will be created (e.g., v0 for v0.1.2)
 #
 # Note: major version tags will always be overwritten if they exists.
+#
+# Unrecognized options and additional version arguments are rejected rather than ignored:
+# a typo such as '--pushh' previously meant "do not push" and still reported success.
 #
 function git::release() {
     local should_push
@@ -99,6 +143,11 @@ function git::release() {
     local sign_flag
     local force_flag
     local version
+    local major
+    local args
+
+    # Keep the original arguments for the error message; the loop below consumes "$@"
+    args="$*"
 
     # Determine if the tag should be pushed to remote
     should_push=false
@@ -124,10 +173,24 @@ function git::release() {
             force_flag="--force"
             shift
             ;;
+        -*)
+            # Reject unknown flags rather than ignoring them. A typo such as '--pushh'
+            # would otherwise silently mean "do not push" and still exit 0.
+            echo "ERROR: unknown option '$1'" >&2
+            return 1
+            ;;
         *)
             # Identify the semver tag to use
+            if [ -n "$version" ]; then
+                echo "ERROR: more than one version given: '$version' and '$1'" >&2
+                return 1
+            fi
+
             if [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                 version="$1"
+            else
+                echo "ERROR: '$1' is not a valid semver tag" >&2
+                return 1
             fi
             shift
             ;;
@@ -136,28 +199,44 @@ function git::release() {
 
     # Check that a valid tag was specified
     if [ -z "$version" ]; then
-        echo "ERROR: did not find a valid semver tag in arguments: $*" >&2
+        echo "ERROR: did not find a valid semver tag in arguments: $args" >&2
         echo "ERROR: semver format is vX.Y.Z, where X, Y, Z are integers" >&2
-        exit 1
+        return 1
     fi
+
+    # Every git call below is checked. Unchecked, a failing 'git tag' or 'git push' left the
+    # trailing 'if' as the function's exit status, so the function reported success after a
+    # hard failure in any context that suppresses 'set -e' (such as 'if git::release ...').
 
     # Create the tag
     echo "Tagging the HEAD commit with '$version'" >&2
-    git tag -a "$version" -m "Release $version" $force_flag $sign_flag
+    if ! git tag -a "$version" -m "Release $version" $force_flag $sign_flag; then
+        echo "ERROR: failed to tag '$version'" >&2
+        return 1
+    fi
 
     # If --push was specified, push the tag to the remote
     if [ "$should_push" = true ]; then
-        git push origin "$version" $force_flag
+        if ! git push origin "$version" $force_flag; then
+            echo "ERROR: failed to push tag '$version'" >&2
+            return 1
+        fi
     fi
 
     # Tag the latest major version
     if [ "$should_tag_major" = true ]; then
         major="${version%%.*}"
-        git tag --force -a "$major" -m "Release $version" $sign_flag
+        if ! git tag --force -a "$major" -m "Release $version" $sign_flag; then
+            echo "ERROR: failed to tag '$major'" >&2
+            return 1
+        fi
 
         # If --push was specified, push the tag to the remote
         if [ "$should_push" = true ]; then
-            git push --force origin "$major"
+            if ! git push --force origin "$major"; then
+                echo "ERROR: failed to push tag '$major'" >&2
+                return 1
+            fi
         fi
     fi
 }

--- a/src/github.bash
+++ b/src/github.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# git.bash - git-related helpers for bash
+# github.bash - GitHub-related helpers for bash
 #
 # Copyright (c) 2025 Mihai Bojin, https://MihaiBojin.com/
 #
@@ -15,12 +15,18 @@ function github::_internal_check_deps() {
 
 # Determines if the current git reference is a version tag.
 # Returns the semantic version prefixed with 'v' if the reference is a tag,
-# or exits with an error message.
+# or returns non-zero with an error message.
 #
 # Usage: github::get_version [--env]
 #       --env: appends VERSION=v#.#.# to the file specified by the GITHUB_ENV environment variable
 function github::get_version() {
-  local store_to_github_env
+  # Must be initialized: it is tested below, and the library runs under 'set -u',
+  # so leaving it unassigned made the function fail unless '--env' was passed.
+  local store_to_github_env=false
+  local ref
+  local git_ref
+  local version
+
   while [[ "$#" -gt 0 ]]; do
     case "$1" in
     --env)
@@ -29,53 +35,53 @@ function github::get_version() {
       ;;
     *)
       echo "Unknown parameter passed: $1" >&2
-      exit 1
+      return 1
       ;;
     esac
   done
 
   # Determine if the GITHUB_REF environment variable is set
-  local ref
   ref="${GITHUB_REF-}"
 
   # If the reference is empty, attempt to get it from git
   if [ -z "$ref" ]; then
     # Attempt to get the reference from git
-    GIT_REF="$(git symbolic-ref -q HEAD || git name-rev --name-only --no-undefined --always HEAD)"
+    # '|| true' keeps a non-git directory from failing the assignment: as a bare
+    # command substitution under 'set -e' that aborted the caller, making the
+    # "could not be retrieved via git either" message below unreachable.
+    git_ref="$(git symbolic-ref -q HEAD || git name-rev --name-only --no-undefined --always HEAD || true)"
 
     # If found, populate the ref variable similarly to GITHUB_REF
-    if [ -n "$GIT_REF" ]; then
-      ref="refs/${GIT_REF%%\^0}"
+    if [ -n "$git_ref" ]; then
+      ref="refs/${git_ref%%\^0}"
     fi
   fi
 
   # Stop, if the reference is empty
   if [[ -z "$ref" ]]; then
     echo "GITHUB_REF is not set and could not be retrieved via git either" >&2
-    exit 1
+    return 1
   fi
 
   if [[ "$ref" =~ refs/tags/(v[0-9]+(\.[0-9]+){0,2})$ ]]; then
-    # Attempt to extract the match
-    VERSION="${BASH_REMATCH[1]}"
-    if [ -z "$VERSION" ]; then
-      # If not found, also try zsh's match array
-      # (this is to support sourcing the script in zsh)
-      # shellcheck disable=SC2154
-      VERSION="${match[1]}"
-    fi
+    # The regex above only validates the shape; the value is taken with parameter expansion
+    # because bash and zsh expose capture groups incompatibly. bash fills BASH_REMATCH, zsh
+    # fills 'match' -- except under 'setopt BASH_REMATCH', where zsh fills BASH_REMATCH with
+    # the *whole* match instead of the group, so reading it there yielded
+    # 'refs/tags/v1.2.3' as the version. Stripping the prefix is correct in every shell.
+    version="${ref##*refs/tags/}"
 
-    echo "Found version: $VERSION" >&2
+    echo "Found version: $version" >&2
     if [ "$store_to_github_env" = true ]; then
       if [ -z "${GITHUB_ENV-}" ]; then
         echo "GITHUB_ENV is not set. Cannot continue." >&2
-        exit 1
+        return 1
       fi
-      echo "VERSION=$VERSION" >>"$GITHUB_ENV"
+      echo "VERSION=$version" >>"$GITHUB_ENV"
     fi
-    echo "$VERSION"
+    echo "$version"
   else
     echo "No matching version found" >&2
-    exit 1
+    return 1
   fi
 }

--- a/src/python.bash
+++ b/src/python.bash
@@ -24,10 +24,9 @@ function python::_internal_check_deps() {
 
 # Extracts the project name as configured in 'pyproject.toml'
 function python::project_name() {
-    local dir
-    if [[ -n "$1" ]]; then
-        dir="$1"
-    fi
+    # Defaulted: the library runs under 'set -u', so a bare "$1" made calling this with no
+    # arguments die on an unbound variable instead of printing the message below.
+    local dir="${1-}"
 
     # error out if dir is not set
     if [[ ! -d "$dir" ]]; then
@@ -41,5 +40,8 @@ function python::project_name() {
         return 1
     fi
 
-    python -c "import toml; print(toml.load('$dir/pyproject.toml')['project']['name'])"
+    # The path is passed as an argument rather than interpolated into the source, so a
+    # directory containing a quote character cannot break or inject into the snippet.
+    python -c "import sys, toml; print(toml.load(sys.argv[1])['project']['name'])" \
+        "$dir/pyproject.toml"
 }


### PR DESCRIPTION
Cleanup only — no new functions, modules, or dependencies. Every fix is the same bug class: **a command failed and the caller was told it succeeded, or a garbage value was produced without complaint.**

## The four that were live

**`git::version_or_sha` returned the literal string `"v"` on an untagged HEAD.** It prefixed `v` before testing for emptiness, so the documented SHA fallback was dead code. On `main` today:

```
$ make all
Concatenating modules ... version 'v'.
dist/releasetools.bash:4   # Version: v
dist/install.sh:17         VERSION="v"
```

That installer fetches `releases/download/v/releasetools.bash`.

**`git::version_tag` picked the wrong tag, two ways.** `--contains` also matches tags on *descendant* commits, so re-running a release for an older tag resolved to the newest one — measured against this repo's real history:

```
git tag --contains v0.0.10  ->  v0, v0.0.10, v0.0.11, v0.0.12   ->  returned v0.0.12
```

And plain `sort` is lexical, so `v0.0.9` outranked `v0.0.10`. Now `--points-at` with `--sort=-version:refname`.

**`base::check_deps` printed `Ok.` and returned 0 with broken dependencies.** The generated `|| ( echo … && exit 1 )` runs `exit` in a subshell, which cannot abort the caller — the abort people saw came from `set -e`. So anywhere `set -e` is suppressed:

```
$ if base::check_deps; then echo ">>> SUCCESS"; fi
'toml' is not installed in your python environment (...).
ERROR: python::_internal_check_deps
Ok.
>>> SUCCESS
```

This is the same failure class the tool exists to prevent, living in the tool. It now accumulates and returns, and reports *every* failing namespace instead of stopping at the first.

**Two functions were unusable under `set -u`.** `github::get_version` left `local store_to_github_env` unassigned, so it only worked when `--env` was passed. `python::project_name` referenced a bare `$1`, making its own "You must provide a directory" message unreachable.

## Also fixed

- `git::release` leaked a global `major`; silently ignored unknown flags (`--pushh` meant "do not push", rc 0); accepted two version arguments (last won); and **reported success after a failing `git tag`/`git push`**, because the trailing `if` became the exit status.
- `git::head_sha` and `git::latest_version` killed a *sourced* shell with no message outside a git repo / with no `origin`.
- No `exit` remains in `src/` — `scripts/install.sh` sources the distributable, so `exit` was uninterceptible.
- `github::get_version` now takes the version by parameter expansion instead of a regex capture group: bash fills `BASH_REMATCH`, zsh fills `match`, and under `setopt BASH_REMATCH` zsh fills `BASH_REMATCH` with the *whole* match — which returned `refs/tags/v1.2.3` as the version.
- `generate-dist.sh`'s shebang strip was line-global and silently ate matching lines from heredocs; now anchored to line 1. The `{{version}}` sed replacement is escaped, in both generators.
- `install.sh`'s checksum `exit 1` ran in a subshell.
- Fixed `README.md`'s `base::::version` (four colons) and `github.bash`'s header, which said `git.bash`.

## Verification

52 assertions covering each fix, plus:

- an `actions/checkout@v7` tag-push simulation at the default `fetch-depth: 1` — `--points-at` resolves the tag, so the release path still stamps `v0.0.13`
- parity on bash **3.2.57** (macOS system bash) and 5.3, and sourceable in zsh
- `shellcheck` clean on `src/`, `scripts/`, and generated `dist/`; `make test` passes
- confirmed against BSD and GNU sed

## Two intentional behavior changes

1. **`git::release` rejects unknown flags and non-semver versions.** `--minor` was never a real flag; it was swallowed while the tag was still created. Docs updated in releasetools/website#3.
2. **`make all` outside a git checkout now fails** instead of stamping `v`. That build previously exited 0 and produced a broken installer.

## Considered and rejected

I initially added `-dirty` to the tag path so a modified checkout would not claim to *be* the release. Simulation showed the cost: that value is baked into `install.sh`'s download URL, so any stray untracked file in the workspace would ship `releases/download/v0.0.13-dirty/…` — a 404 for every consumer. Reverted; `git::head_sha` still reports dirtiness.

## Known, not addressed here

`base::install_location` returns the cwd with rc 0 in zsh (unguarded `${BASH_SOURCE[0]}`); `main.sh` has the same issue. `base::check_deps` will still propagate an `exit` from a module and leaks module stdout — both latent. `install.sh` hard-codes BSD `shasum` with no `sha256sum` fallback.

**Before tagging:** `action.yml`'s `default: "v0.0.12"` must be bumped in the commit that gets tagged, or the `test-default` job will exercise the old dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)