### PR TITLE
chore(renovate): do not pin this repository's own action

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,13 @@
     "github>MihaiBojin/renovate:group-github-actions",
     "github>MihaiBojin/renovate:lock-file-maintenance",
     "helpers:pinGitHubActionDigests"
+  ],
+  "packageRules": [
+    {
+      "description": "Never pin this repository's own action. test-release.yaml exists to verify what a consumer referencing 'releasetools/cli@v0' actually gets, and git::release --major force-moves the v0 tag onto every release. A digest pin would freeze the self-test to the previous release's action code and its baked-in action.yml default version, so the job would validate the previous release while reporting success for the new one.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["releasetools/cli"],
+      "pinDigests": false
+    }
   ]
 }


### PR DESCRIPTION
Config-only. Prevents the `releasetools/cli@v0` half of #22 while keeping the third-party pin.

## Why the self-reference must not be pinned

`test-release.yaml` exists to answer *"what does a consumer writing `uses: releasetools/cli@v0` actually get?"* — `test-default` deliberately passes no `version:` input. Pinning the digest freezes two things: the action's code, and the `default:` version baked into `action.yml` at that commit.

It is also **stale by construction**, because `git::release --major` force-moves `v0` onto every release:

```bash
git tag --force -a "$major" -m "Release $version"
git push --force origin "$major"
```

Verified against the current repo:

```
v0^{commit}       -> 964f2bb77ea50d9c1c9aa70e9cb2e7c19212c8a6
v0.0.12^{commit}  -> 964f2bb77ea50d9c1c9aa70e9cb2e7c19212c8a6   # same commit
#22 pins          -> 964f2bb77ea50d9c1c9aa70e9cb2e7c19212c8a6
```

Correct today, wrong the moment the next release is tagged. And the ordering makes it worse: `test-release.yaml` triggers on the tag push, at which point `tag.sh` has already moved `v0` to the new commit — while the committed digest still points at the previous one. So `test-default` would install and validate the **previous** release, pass green, and tell you nothing about the release being cut.

That is the same failure mode as the bugs in #25: a check that cannot fail for the reason it exists.

## Third-party actions stay pinned

Deliberately scoped to `releasetools/cli` only. `actions/checkout` is already digest-pinned in both workflows, and `softprops/action-gh-release` runs in a job holding `contents: write` — trading silent floating updates for reviewable Renovate PRs is the right posture there. Yes, you stop picking up the latest `v3` automatically; that is what digest pinning is *for*, and Renovate keeps the digest current.

The distinction is that for our *own* action, following the moving tag **is** the test.

## Change

`helpers:pinGitHubActionDigests` expands to `{"matchDepTypes": ["action"], "pinDigests": true}` — it has no notion of "this repository's own action". Adding a narrower rule after it:

```json
{
  "matchManagers": ["github-actions"],
  "matchDepNames": ["releasetools/cli"],
  "pinDigests": false
}
```

Repo-level `packageRules` are applied after extended presets, so the narrower rule wins.

Validated with Renovate's own tooling:

```
$ npx --package renovate renovate-config-validator renovate.json
 INFO: Validating renovate.json
 INFO: Config validated successfully
```

## After merging

Close #22 — Renovate will re-raise it with only the `softprops/action-gh-release` pin, which is the part worth taking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)