### PR TITLE
Verify action.yml's version against the release tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # Runs before the dist is built, so a stale default fails the release instead of
+      # publishing one that every 'uses: releasetools/cli@v0' consumer ignores.
+      - name: Verify action.yml matches the tag
+        run: scripts/assert-action-version.sh "$GITHUB_REF_NAME"
+        if: startsWith(github.ref, 'refs/tags/')
+
       - name: Build the dist
         run: make all
         if: startsWith(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@ This toolkit represents a collection of bash scripts for various purposes.
 
 ```shell
 # curl
-bash <(curl -sSL "https://github.com/releasetools/cli/releases/download/v0.0.12/install.sh")
+bash <(curl -sSL "https://github.com/releasetools/cli/releases/latest/download/install.sh")
 
 # or wget
-bash <(wget -q -O- "https://github.com/releasetools/cli/releases/download/v0.0.12/install.sh")
+bash <(wget -q -O- "https://github.com/releasetools/cli/releases/latest/download/install.sh")
 ```
+
+> These URLs always resolve to the most recent release. To install a specific version,
+> replace `latest/download` with `download/vX.Y.Z`.
 
 Or alternatively, with `brew`:
 
@@ -82,8 +85,8 @@ steps:
 
   # Customizations
   # with:
-  #   # Pin a specific version (defaults to latest)
-  #   version: "v0.0.12"
+  #   # Pin a specific version (defaults to the version this action was released with)
+  #   version: "vX.Y.Z"
   # env:
   #   # Configure the installation directory
   #   RELEASETOOLS_INSTALL_DIR: /home/runner/.local/share

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,10 @@ description: "Installs release tools in a GitHub workflow"
 author: "Mihai Bojin <mihai.bojin@gmail.com>"
 inputs:
   version:
-    description: "The version to install, defaults to the latest release"
+    # Not "the latest release": this is the version pinned at the ref this action was
+    # resolved from, so 'releasetools/cli@v0' installs whatever v0 currently points at.
+    # scripts/assert-action-version.sh keeps it equal to the tag being released.
+    description: "The version to install, defaults to the release this action ships with"
     required: false
     default: "v0.0.12"
 

--- a/scripts/assert-action-version.sh
+++ b/scripts/assert-action-version.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# assert-action-version.sh - checks that action.yml's default version matches a release tag
+#
+# 'action.yml' pins the version that a consumer writing 'uses: releasetools/cli@v0'
+# installs, because that input has no other source. 'git::release --major' force-moves
+# the v0 tag onto every release, so if the default is not bumped in the commit being
+# tagged, @v0 keeps serving the previous release -- and the test-default job in
+# test-release.yaml passes while exercising the old distributable.
+#
+# Nothing else notices, which is why this is a check rather than a comment.
+#
+# Usage: assert-action-version.sh vX.Y.Z
+#
+# Copyright (c) 2025 Mihai Bojin, https://MihaiBojin.com/
+#
+# Licensed under the Apache License, Version 2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -euo pipefail
+
+# Set the base directory as the parent of the current script
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd -P)"
+readonly DIR
+
+ACTION_FILE="$DIR/action.yml"
+readonly ACTION_FILE
+
+EXPECTED="${1-}"
+readonly EXPECTED
+
+if [ -z "$EXPECTED" ]; then
+  echo "ERROR: no version given." >&2
+  echo "Usage: $(basename "$0") vX.Y.Z" >&2
+  exit 1
+fi
+
+if [ ! -f "$ACTION_FILE" ]; then
+  echo "ERROR: '$ACTION_FILE' does not exist." >&2
+  exit 1
+fi
+
+# Read the first 'default: "v..."' line. Restricted to a v-prefixed semver value so a
+# future unrelated 'default:' key cannot be picked up by accident.
+DECLARED="$(sed -n 's/^[[:space:]]*default:[[:space:]]*"\(v[0-9][^"]*\)".*/\1/p' "$ACTION_FILE" | head -1)"
+readonly DECLARED
+
+# An empty result means the file no longer has the shape this check assumes. Treating
+# that as a pass would silently disable the check, which is the failure it exists to stop.
+if [ -z "$DECLARED" ]; then
+  echo "ERROR: could not find a 'default: \"vX.Y.Z\"' line in '$ACTION_FILE'." >&2
+  echo "ERROR: if the input was renamed or restructured, update this check too." >&2
+  exit 1
+fi
+
+if [ "$DECLARED" != "$EXPECTED" ]; then
+  echo "ERROR: action.yml declares version '$DECLARED', but the release is '$EXPECTED'." >&2
+  echo "ERROR: bump the 'default:' value in action.yml and commit it before tagging," >&2
+  echo "ERROR: or every 'uses: releasetools/cli@v0' consumer will keep installing" >&2
+  echo "ERROR: '$DECLARED' after the v0 tag moves." >&2
+  exit 1
+fi
+
+echo "action.yml default version matches the release ($EXPECTED)." >&2

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -18,4 +18,20 @@ readonly DIR
 # shellcheck source=/dev/null
 source "$DIR/src/git.bash"
 
+# Find the semver argument, using the same shape git::release accepts. If there isn't one,
+# leave the diagnostic to git::release rather than reporting it twice.
+version=""
+for arg in "$@"; do
+  if [[ "$arg" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    version="$arg"
+    break
+  fi
+done
+
+# Checked before the tag is created, so a stale action.yml costs an edit rather than a
+# force-moved tag and a released distributable nobody installs.
+if [ -n "$version" ]; then
+  "$DIR/scripts/assert-action-version.sh" "$version"
+fi
+
 git::release "$@"


### PR DESCRIPTION
Closes the release-ordering trap noted in #25.

## The trap

`action.yml`'s `default:` is the *only* source for what a consumer writing `uses: releasetools/cli@v0` installs. And `git::release --major` force-moves `v0` onto every release:

```bash
git tag --force -a "$major" -m "Release $version"
git push --force origin "$major"
```

So if the default is still `v0.0.12` when you tag `v0.0.13`:

- every `@v0` consumer keeps installing **v0.0.12**, indefinitely
- `test-release.yaml`'s `test-default` job installs v0.0.12, passes green, and tells you nothing about the release you just cut

Nothing else notices — which is why this is now a check rather than a comment.

## The fix

`scripts/assert-action-version.sh`, called from both ends of the release path:

| Where | Why there |
|---|---|
| `scripts/tag.sh`, before `git::release` | Earliest possible feedback — a stale default costs an edit, not a force-moved tag |
| `release.yaml`, before `make all` | A tag pushed by any other route still can't publish a stale default |

In `tag.sh` the semver argument is located the same way `git::release` accepts it (any position), and when there isn't one the diagnostic is left to `git::release` rather than reported twice.

The check **fails when it cannot find a `default: "vX.Y.Z"` line at all**. Treating that as a pass would silently disable it — the exact failure mode it exists to prevent.

```
$ scripts/tag.sh v0.0.13
ERROR: action.yml declares version 'v0.0.12', but the release is 'v0.0.13'.
ERROR: bump the 'default:' value in action.yml and commit it before tagging,
ERROR: or every 'uses: releasetools/cli@v0' consumer will keep installing
ERROR: 'v0.0.12' after the v0 tag moves.
```

## Two copies deleted instead of checked

The version appeared in four places. The README install URLs now use GitHub's latest-release redirect, verified working:

```
https://github.com/releasetools/cli/releases/latest/download/install.sh   -> HTTP 200
```

so they never need bumping. The commented workflow example uses a placeholder. That leaves exactly one copy in this repo — the load-bearing one — and it is now checked.

## Also

Corrected the `version` input description, which claimed the default was *"the latest release"*. It is not, and believing it is what makes this trap invisible.

## Why not make the default dynamic

`action-install.sh` could resolve the latest tag at run time (`git ls-remote --sort=version:refname`, which needs no token and no API quota — verified, 0.3s). That would delete the last copy.

Rejected because it trades away what #26 just argued for: with a dynamic default, `uses: releasetools/cli@<sha>` would no longer imply a fixed CLI version, so digest-pinning consumers lose reproducibility. Keeping the pin and asserting it preserves that, and doesn't change what any consumer gets.

## Verification

18 assertions: exit codes in all four directions (match, mismatch, missing argument, unrecognisable `action.yml`); `tag.sh` refusing to tag a version `action.yml` does not declare, and succeeding once bumped; flags in any order; the non-semver case still reported by `git::release`; and the workflow calling the check before *both* the build and publish steps.

`make test` passes. `actionlint` is clean on `release.yaml`.

> Unrelated, pre-existing: `actionlint` flags `macos-13` in `test-release.yaml` as an unknown runner label — GitHub has retired that image. Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)