### PR TITLE
Notify the Homebrew tap on release, and drop the retired macos-13 runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,3 +38,22 @@ jobs:
             dist/releasetools.bash.sha256
             dist/install.sh
             README.md
+
+      # The tap bumps its formula from this release. It also polls daily, so this only
+      # shortens the delay -- which is why a missing token is a notice, not a failure.
+      # GITHUB_TOKEN cannot dispatch to another repository; HOMEBREW_TAP_TOKEN needs
+      # 'contents: write' on releasetools/homebrew-tap.
+      - name: Notify the Homebrew tap
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::notice::HOMEBREW_TAP_TOKEN is not set; the tap will pick up $VERSION on its next scheduled run."
+            exit 0
+          fi
+
+          gh api --method POST repos/releasetools/homebrew-tap/dispatches \
+            -f event_type=upstream-released \
+            -f "client_payload[version]=$VERSION"

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -42,7 +42,7 @@ jobs:
           if [[ "$GITHUB_REF" =~ refs/tags/(v[0-9]+\..*) ]]; then
             VERSION="${BASH_REMATCH[1]}"
             echo "Found release version: $VERSION" >&2
-            echo "VERSION=$VERSION" >> $GITHUB_ENV
+            echo "VERSION=$VERSION" >>"$GITHUB_ENV"
           else
             echo "No matching version found" >&2
             exit 1
@@ -84,7 +84,7 @@ jobs:
           if [[ "$GITHUB_REF" =~ refs/tags/(v[0-9]+\..*) ]]; then
             VERSION="${BASH_REMATCH[1]}"
             echo "Found release version: $VERSION" >&2
-            echo "VERSION=$VERSION" >> $GITHUB_ENV
+            echo "VERSION=$VERSION" >>"$GITHUB_ENV"
           else
             echo "No matching version found" >&2
             exit 1
@@ -117,9 +117,11 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
-          - macos-13
+          # macos-13 was retired by GitHub; the label no longer resolves to a runner.
+          # macos-26 replaces it, matching the images the homebrew tap tests against.
           - macos-14
           - macos-15
+          - macos-26
     runs-on: ${{ matrix.os }}
     needs: wait-for-release
     steps:
@@ -130,7 +132,7 @@ jobs:
           if [[ "$GITHUB_REF" =~ refs/tags/(v[0-9]+\..*) ]]; then
             VERSION="${BASH_REMATCH[1]}"
             echo "Found release version: $VERSION" >&2
-            echo "VERSION=$VERSION" >> $GITHUB_ENV
+            echo "VERSION=$VERSION" >>"$GITHUB_ENV"
           else
             echo "No matching version found" >&2
             exit 1


### PR DESCRIPTION
Two release-path fixes, plus the actionlint findings in the file they touch.

## Notify the tap on release

releasetools/homebrew-tap#16 bumps the formula from the published release. It already polls daily, so this only shortens the delay — which is why a missing token is a `::notice::` rather than a failure:

```yaml
- name: Notify the Homebrew tap
  if: startsWith(github.ref, 'refs/tags/')
  env:
    GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
    VERSION: ${{ github.ref_name }}
  run: |
    if [ -z "${GH_TOKEN:-}" ]; then
      echo "::notice::HOMEBREW_TAP_TOKEN is not set; the tap will pick up $VERSION on its next scheduled run."
      exit 0
    fi
    gh api --method POST repos/releasetools/homebrew-tap/dispatches \
      -f event_type=upstream-released \
      -f "client_payload[version]=$VERSION"
```

`GITHUB_TOKEN` cannot dispatch to another repository, so this needs a **`HOMEBREW_TAP_TOKEN`** secret with `contents: write` on `releasetools/homebrew-tap`. Until one exists the step is a no-op — nothing here can break a release.

The tag goes over as `client_payload.version`, so the tap bumps to the release that just shipped rather than whatever is newest when it wakes up.

Manual bumping is handled on the tap side by the `workflow_dispatch` input in releasetools/homebrew-tap#16 — optional `vX.Y.Z`, defaulting to the newest release.

## Drop the retired macos-13 runner

`test-platforms` still listed `macos-13`. GitHub has retired that image, so the label no longer resolves to a runner and the leg would fail to schedule. actionlint rejects it against its current label list:

```
label "macos-13" is unknown. available labels are ... "macos-26", "macos-15", "macos-14" ...
```

The last `test-release` run (v0.0.12, 2025-09-06) predates the retirement and passed, which is why this hasn't bitten yet — it would bite on the next release.

Replaced with `macos-26`, which also matches the images the homebrew tap tests against, so the two repos now cover the same macOS set.

## Also

Quoted the three `>> $GITHUB_ENV` redirections in the same file — actionlint's only other findings there. Both workflows are now clean:

```
$ actionlint .github/workflows/release.yaml .github/workflows/test-release.yaml
$
```

`make test` passes; `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)