### PR TITLE
Install a TOML reader when the interpreter has none

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,11 +13,35 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # No dependency install step: python:: reads pyproject.toml with tomllib, which is in
-    # the standard library from python 3.11, so there is nothing left to install.
     - name: Install the release tools
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
       run: |
         ${{ github.action_path }}/scripts/action-install.sh
+
+    # python:: reads TOML with tomllib, which is in the standard library from python 3.11,
+    # so this is a no-op on any current runner. It exists for the ones that are not:
+    # ubuntu-22.04 still ships 3.10, where the library falls back to the third-party
+    # 'toml' and cannot work without it. Asking the library itself keeps the condition in
+    # one place instead of duplicating the probe here.
+    - name: Install a TOML reader if the interpreter has none
+      shell: bash
+      run: |
+        if releasetools python::_internal_check_deps >/dev/null 2>&1; then
+          exit 0
+        fi
+
+        if ! command -v pip >/dev/null 2>&1; then
+          echo "::notice::The python:: module cannot read TOML here and pip is unavailable. Every other module still works."
+          exit 0
+        fi
+
+        echo "Interpreter has no tomllib; installing 'toml' as a fallback..." >&2
+        pip install --user toml
+
+        # Report rather than fail: only python::project_name needs this, and failing the
+        # install step would take out workflows that never touch the python:: module.
+        if ! releasetools python::_internal_check_deps >/dev/null 2>&1; then
+          echo "::notice::Installed 'toml' but the python:: module still cannot read TOML. Every other module still works."
+        fi


### PR DESCRIPTION
**v0.0.14 regressed ubuntu-22.04, and this fixes it.** My fault: #33 dropped the `toml` dependency and with it the action step that installed the package, but ubuntu-22.04 still ships python **3.10** at `/usr/bin/python3`, which predates `tomllib`. The library falls back to third-party `toml` there and now had nothing to fall back to.

```
Cannot read TOML with /usr/bin/python3.
Use python 3.11 or newer, which bundles 'tomllib', or install the
'toml' package for this interpreter.
ERROR: python::_internal_check_deps
```

The release smoke test caught it, which is exactly what it's for:

| platform | python3 | v0.0.14 |
|---|---|---|
| macos-14 / 15 / 26 | 3.11+ | pass — and newly fixed by #33 |
| ubuntu-24.04 | 3.12 | pass |
| **ubuntu-22.04** | **3.10** | **fail** |

So the Homebrew fix holds; only the one interpreter without `tomllib` broke.

## The fix

The action installs `toml` **only when the resolved interpreter can't read TOML** — a no-op on every runner shipping 3.11 or newer:

```bash
if releasetools python::_internal_check_deps >/dev/null 2>&1; then
  exit 0
fi
...
pip install --user toml
```

The condition is *asked of the library* rather than reimplemented in YAML, so the check and the remedy can't drift apart. That drift is roughly how the original bug survived: the formula installed `toml` for one interpreter while the check probed another.

It **reports rather than fails** when there's no pip, or when installing doesn't help. Only `python::project_name` needs TOML, and failing the install step would break workflows that never touch the `python::` module. That's a deliberate exception to the fail-loudly rule this repo has been converging on — the loud failure belongs in `base::check_deps`, which still gives an accurate answer naming both remedies, not in a step that would take out unrelated jobs.

## Scope

Homebrew is unaffected — `depends_on "python3"` pulls a current interpreter, and the tap's matrix is all 3.11+. releasetools/homebrew-tap#19 is already bumped to v0.0.14 and passing on that basis.

Direct curl/wget installs on a 3.10 interpreter still get the accurate failure from `base::check_deps`. The module genuinely can't work there without help, and saying so is the point.

`action.yml` parses, and the embedded script is shellcheck-clean. (`actionlint` reports `unexpected key "runs"` — it lints workflows, and this is an action definition.)

Needs a **v0.0.15** to reach `@v0` consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)